### PR TITLE
Update IC2.cfg

### DIFF
--- a/config/IC2.cfg
+++ b/config/IC2.cfg
@@ -65,7 +65,7 @@ general {
     B:enableBurningScrap=true
 
     # Enable crafting of buckets out of tin
-    B:enableCraftingBucket=true
+    B:enableCraftingBucket=false
 
     # Enable crafting of Industrial Credit coins
     B:enableCraftingCoin=true


### PR DESCRIPTION
disabled tin bucket crafting, due to exploit possibility
