### PR TITLE
Removed redundant Limestone worldgen

### DIFF
--- a/config/Chisel.cfg
+++ b/config/Chisel.cfg
@@ -95,7 +95,7 @@ general {
     B:"Alternative recipe"=false
 
     # Amount of limestone to generate in the world; use 0 for none
-    I:"Worldgen limestone amount"=4
+    I:"Worldgen limestone amount"=0
 
     # Amount of marble to generate in the world; use 0 for none
     I:"Worldgen marble amount"=8

--- a/config/emashercore.cfg
+++ b/config/emashercore.cfg
@@ -43,7 +43,7 @@ general {
     I:"E: Cassiterite Ore Per Chunk"=6
     I:"E: Emery Ore Per Chunk"=6
     I:"E: Galena Ore Per Chunk"=6
-    I:"E: Limestone Per Chunk"=3
+    I:"E: Limestone Per Chunk"=6
     I:"E: Native Copper Ore Per Chunk"=12
     I:"E: Pentlandite Ore Per Chunk"=4
     I:"E: Red SandStone Per Chunk"=20


### PR DESCRIPTION
Removed the Limestone worldgen from Chisel and doubled the number of
veins per chunk in Emasher's Core to compensate.
