### PR TITLE
Fix default HUD values for AM2 - Closes #72

### DIFF
--- a/config/AM2/AM2.cfg
+++ b/config/AM2/AM2.cfg
@@ -149,8 +149,8 @@ general {
 ####################
 
 guis {
-    D:AffinityPositionX=468.0
-    D:AffinityPositionY=0.0
+    D:AffinityPositionX=0.00749063678085804
+    D:AffinityPositionY=0.3074204921722412
     D:ArmorPositionBootsX=0.004166666883975267
     D:ArmorPositionBootsY=0.6352941393852234
     D:ArmorPositionChestX=0.004166666883975267


### PR DESCRIPTION
This change will place the affinity HUD on the screen where it can actually be dragged around and configured.
