### PR TITLE
Fix for MPS field of view bug

### DIFF
--- a/config/machinemuse/numina.cfg
+++ b/config/machinemuse/numina.cfg
@@ -6,7 +6,7 @@
 
 general {
     B:"Debugging info"=false
-    B:"Ignore speed boosts for field of view"=false
+    B:"Ignore speed boosts for field of view"=true
     B:"Use Sounds"=true
 }
 


### PR DESCRIPTION
When using sprint assist the field of view is excessively large and is the same whether sprinting, walking or standing still.

Below are screenshots comparing normal field of view to sprint assist field of view both are while standing still.

![normal-fov](https://f.cloud.github.com/assets/2286349/2167372/4d2ff542-9517-11e3-8daa-d1e678688ae4.png)

![bugged-fov](https://f.cloud.github.com/assets/2286349/2167375/54413c9c-9517-11e3-8347-b5167b364474.png)
