### PR TITLE
Modify IguanaTweaks config

### DIFF
--- a/config/IguanaTweaksTConstruct.cfg
+++ b/config/IguanaTweaksTConstruct.cfg
@@ -11,16 +11,16 @@ crafting {
     B:easyBlankPatternRecipe=true
 
     # Allows you to make tool parts in a normal crafting window
-    B:easyPartCrafting=true
+    B:easyPartCrafting=false
 
     # Allows you to rotate the the tier 1 patterns in a normal crafting window
-    B:easyPatternCrafting=true
+    B:easyPatternCrafting=false
 
     # Allows you create tinkers tools in a normal crafting window
-    B:easyToolCreation=true
+    B:easyToolCreation=false
 
     # Allows you add modifications to tools in a normal crafting window
-    B:easyToolModification=true
+    B:easyToolModification=false
 }
 
 
@@ -148,7 +148,7 @@ leveling {
     B:toolLevelingExtraModifiers=true
 
     # Gives a random bonus every level, if false and levelling is on modifiers are given at levels 2 and 4 (requires 'toolLeveling=true')
-    B:toolLevelingRandomBonuses=true
+    B:toolLevelingRandomBonuses=false
     I:toolLevelingRatePercentage=100
     I:weaponLevelingRatePercentage=100
 
@@ -171,22 +171,22 @@ leveling {
 
 modifiers {
     # Silky Cloth can be used to remove all modifiers from a tool (currently safe but not working)
-    B:addCleanModifier=true
+    B:addCleanModifier=false
 
     # Electric modifier requires 2 modifiers slots instead of 1
-    B:moreExpensiveElectric=true
+    B:moreExpensiveElectric=false
 
     # Silky Cloth needs gold ingots, instead of nuggets
-    B:moreExpensiveSilkyCloth=true
+    B:moreExpensiveSilkyCloth=false
 
     # Silky Jewel needs emerald block, instead of one emerald
-    B:moreExpensiveSilkyJewel=true
+    B:moreExpensiveSilkyJewel=false
 
     # Rate tools with moss repair (TC default 3)
     I:mossRepairSpeed=3
 
     # Amount each piece of redstone increases mining speed (tinkers default is 8)
-    I:redstoneEffect=4
+    I:redstoneEffect=8
 }
 
 
@@ -206,15 +206,15 @@ other {
     # Change durability of all materials here (higher = tougher)
     I:durabilityPercentage=100
     B:easyBlankPatternRecipe=true
-    B:easyPartCrafting=true
-    B:easyPatternCrafting=true
-    B:easyToolCreation=true
-    B:easyToolModification=true
+    B:easyPartCrafting=false
+    B:easyPatternCrafting=false
+    B:easyToolCreation=false
+    B:easyToolModification=false
 
     # Change mining speed of all materials here (higher = faster)
     I:miningSpeedPercentage=100
-    B:moreExpensiveElectric=true
-    B:moreExpensiveSilkTouch=true
+    B:moreExpensiveElectric=false
+    B:moreExpensiveSilkTouch=false
     I:mossRepairSpeed=3
 
     # Can you replace parts of existing tools?
@@ -222,14 +222,14 @@ other {
 
     # Shows information about tool parts in the mouseover tooltip
     B:partTooltips=true
-    B:pickaxeBoostRequired=true
-    I:redstoneEffect=4
+    B:pickaxeBoostRequired=false
+    I:redstoneEffect=8
 
     # Removes the random chance of getting flint from gravel
-    B:removeFlintDrop=true
+    B:removeFlintDrop=false
 
     # Removes the recipe for Tinker's Construct's stone torch
-    B:removeStoneTorchRecipe=true
+    B:removeStoneTorchRecipe=false
 
     # Do Tinker's tools on the ground never despawn?
     B:toolsNeverDespawn=true
@@ -266,7 +266,7 @@ pickboosting {
     B:mobHeadPickaxeBoost=true
 
     # Pickaxes only mine upto their head material level and need a mob head modifier OR leveling boost to advance
-    B:pickaxeBoostRequired=true
+    B:pickaxeBoostRequired=false
 }
 
 
@@ -302,133 +302,26 @@ repairs {
 
 restrictions {
     # Allow certain stone tools to be built (if equivalent flint tool can also be made, the stone version is allowed)
-    B:allowStoneTools=false
+    B:allowStoneTools=true
 
     # Pattern ids to restrict for bone parts
     I:restrictedBoneParts <
-        2
-        5
-        6
-        7
-        9
-        10
-        11
-        13
-        14
-        15
-        16
-        17
-        18
-        19
-        20
-        21
-        22
-        23
-        24
      >
 
     # Pattern ids to restrict for cactus parts
     I:restrictedCactusParts <
-        2
-        3
-        4
-        5
-        6
-        7
-        8
-        10
-        11
-        12
-        13
-        14
-        15
-        16
-        17
-        18
-        19
-        20
-        21
-        22
-        23
-        24
-        25
      >
 
     # Pattern ids to restrict for flint parts
     I:restrictedFlintParts <
-        1
-        5
-        6
-        7
-        8
-        9
-        10
-        11
-        14
-        15
-        16
-        17
-        18
-        19
-        20
-        21
-        22
-        23
-        24
      >
 
     # Pattern ids to restrict for paper parts
     I:restrictedPaperParts <
-        2
-        3
-        4
-        5
-        6
-        7
-        8
-        10
-        11
-        12
-        13
-        14
-        15
-        16
-        17
-        18
-        19
-        20
-        21
-        22
-        23
-        24
-        25
      >
 
     # Pattern ids to restrict for slime parts
     I:restrictedSlimeParts <
-        2
-        3
-        4
-        5
-        6
-        7
-        8
-        10
-        11
-        12
-        13
-        14
-        15
-        16
-        17
-        18
-        19
-        20
-        21
-        22
-        23
-        24
-        25
      >
 
     # Pattern ids to restrict for stone parts
@@ -437,24 +330,6 @@ restrictions {
 
     # Pattern ids to restrict for wood parts
     I:restrictedWoodParts <
-        2
-        4
-        5
-        6
-        7
-        10
-        13
-        14
-        15
-        16
-        17
-        18
-        19
-        20
-        21
-        22
-        23
-        24
      >
 }
 


### PR DESCRIPTION
Undoes most/all of the nerfs IguanaTweaks makes, but leaves in features
such as pickaxe level boosting (minus the nerf) and extra modifier slots
(minus the random crap).
