### PR TITLE
Update core.cfg

### DIFF
--- a/config/mystcraft/core.cfg
+++ b/config/mystcraft/core.cfg
@@ -36,7 +36,7 @@ entity {
 ####################
 
 general {
-    B:crafting.linkeffects.disarm.enabled=true
+    B:crafting.linkeffects.disarm.enabled=false
     B:crafting.linkeffects.following.enabled=true
     B:crafting.linkeffects.generate_platform.enabled=true
     B:crafting.linkeffects.intra_linking.enabled=true


### PR DESCRIPTION
With receptacles being enabled again, disarming needs to be disabled to prevent it from becoming a source of item duplication.
