### PR TITLE
AM2 Dig Spell Blacklist

### DIFF
--- a/config/AM2/AM2.cfg
+++ b/config/AM2/AM2.cfg
@@ -143,7 +143,7 @@ general {
     B:WitchwoodLeafParticles=true
 
     # Comma-separated list of block IDs that dig cannot break.  If a block is flagged as unbreackable in code, Dig will already be unable to break it.  There is no need to set it here (eg, bedrock, etc.).  Dig also makes use of Forge block harvest checks.  This is mainly for fine-tuning.
-    S:dig_blacklist=
+    S:dig_blacklist=851,852,2271,2412,2440,2444,2445,2446,2447,2448,2453,2527,3144,3464,3468,3474,3475,3484,3485,4327,6027,7130,7131,7132,7133,7134,7135,7137,7138,7139,7140,7141,7142,7143,7144,7145,7146,7147,7148,7149,7150,7151,7152,7153,7157,7158,7159,7160,7161,7162,7163,7164,10456,10457,10459,10460,10556,10557,10558,10559,10560,10561,10656,10657,10658,19416,19417,19418,19419,19420,19421,19422,19423,19424,19425,19426,19427,19436,19437,19438,19439,19440,19443,19456,19457,19458,19459,19460,19461,19464,19476,19477,19478,19479,19480,25298,25304,30184
     I:mage_villager_profession_id=29
 
     # Comma-separated list of dimension IDs that AM should *not* do worldgen in.


### PR DESCRIPTION
Adding known problem blocks to Dig spell to prevent dupe issues and/or blocks not dropping.  Includes select blocks from following mods: Additional Buildcraft Objects, Applied Energistics, Buildcraft, Dartcraft, Extra Utilities, GregTech, IC2-Experimental, Logistics Pipes, Mekanism, MineFactory Reloaded, Thaumcraft.
