### PR TITLE
Update Mekanism.cfg

### DIFF
--- a/config/Mekanism.cfg
+++ b/config/Mekanism.cfg
@@ -49,7 +49,7 @@ general {
     B:FancyUniversalCableRender=true
     B:ForceBuildcraftPower=true
     B:Holidays=true
-    D:HydrogenEnergyDensity=2000.0
+    D:HydrogenEnergyDensity=90.0
     D:JoulesToEU=10.0
     D:JoulesToMJ=25.0
     B:LogPackets=false


### PR DESCRIPTION
Change HydrogenEnergyDensity to 90 from 2000. The Electrolytic Separator was consuming 1600 RF/t. The Gas-Powered Generator was producing 800 RF/t.

In light of this, and the use of the Electrolytic Separator being used to triple ore, 90 is a fair value because it costs 90 to make Oxygen and Hydrogen, then 80 to Purify, 12 to Crush, 18 to Enrich and finally 7 to Smelt.

So, 90+80+12+18+7 = 207.

Then you recoup 45 back from the Gas-Powered Generator (Hydrogen) so that drops it down to 162 net power loss.

The power loss incurred for a basic ore doubling using TE machines is 40 (Pulverizer) + 40 (Redstone Furnace.) This is a little more than twice the power cost for tripling ore which I see as balanced.

Thanks for listening,
Siigari
