### PR TITLE
Update TreeCapitator.cfg

### DIFF
--- a/config/TreeCapitator.cfg
+++ b/config/TreeCapitator.cfg
@@ -781,9 +781,9 @@ tree_and_mod_configs {
     }
 
     tconstruct {
-        S:axeIDList=<tools:Axe>; <tools:Lumber Axe>; <tools:Mattock>
+        S:axeIDList=<tools:Axe>; <tools:Mattock>
         S:configPath=TinkersWorkshop.txt
-        S:itemConfigKeys=tools:Axe; tools:Lumber Axe; tools:Mattock
+        S:itemConfigKeys=tools:Axe; tools:Mattock
         S:modID=TConstruct
         B:overrideIMC=false
         B:useShiftedItemID=true


### PR DESCRIPTION
Removed lumber axe from database due to it's tree capitator function interfering with the treecapitator mod function resulting in it taking longer to cut a tree down then a normal axe.
